### PR TITLE
Add new file extension 'bean'

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,6 +2,6 @@
     name: beancount-check
     entry: bean-check
     language: python
-    files: .*(.beancount|.ledger)$
+    files: .*(\.beancount|\.ledger)$
     require_serial: true
     additional_dependencies: [beancount]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,6 +2,6 @@
     name: beancount-check
     entry: bean-check
     language: python
-    files: .*(\.beancount|\.ledger)$
+    files: .*(\.bean|\.beancount|\.ledger)$
     require_serial: true
     additional_dependencies: [beancount]


### PR DESCRIPTION
I have used the `.bean` extension for my ledger and would rather avoid having to rename my files just to please the pre-commit hook.

I also fixed the regex to escape the `.`, I think it was the *special* `.` before.

 Now that I think about it, I think I should have moved it outside of the `(...|...)` shenanigans to avoid repeating the escaping each time: which do you prefer?